### PR TITLE
Upgrade gulp-sass version to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "gulp-livereload": "^2.1.1",
     "gulp-minify-css": "^0.3.11",
     "gulp-rename": "^1.2.0",
-    "gulp-sass": "^1.2.0",
+    "gulp-sass": "^2.1.0",
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.1",
     "gulp-zip": "^2.0.2",


### PR DESCRIPTION
Gulp-sass version 1.2.0 throws [this error](https://github.com/sass/node-sass/issues/918) due to node-sass. Upgrading to 2.1.0 fixes it.
